### PR TITLE
Allow local_confseed to have to run a later upgrade step

### DIFF
--- a/db/install.php
+++ b/db/install.php
@@ -30,7 +30,7 @@ defined('MOODLE_INTERNAL') || die();
  * @return bool result
  */
 function xmldb_local_confseed_install() {
-    global $CFG, $DB;
+    global $CFG;
 
     // We always want to run the upgrade.
     require_once($CFG->dirroot . '/local/confseed/db/upgrade.php');

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -43,12 +43,8 @@ function xmldb_local_confseed_upgrade($oldversion) {
         include($CFG->dirroot . '/config-seed.php');
     }
     if (!isset($CONFSEED)) {
-        if (isset($CFG->CONFSEED)) {
-            $CONFSEED = $CFG->CONFSEED;
-        } else {
-            // The CONFSEED attribute is not set, local/confseed doesn't do anything.
-            return true;
-        }
+        // The CONFSEED attribute is not set, local/confseed doesn't do anything.
+        return true;
     }
 
     // Start by uninstalling plugins, only if moodle is installed.

--- a/version.php
+++ b/version.php
@@ -43,6 +43,12 @@ if (!isset($plugin->version)) {
     }
 }
 
+// The rolesactive = 1 marks a finished Moodle install.
+if ($CFG->rolesactive != 1) {
+    // Pretend it's a one-off lower version, so we can install+upgrade in one step.
+    $plugin->version = (string)((int)$plugin->version - 1);
+}
+
 $plugin->requires  = 2017051502; // Requires Moodle 3.3.
 $plugin->component = 'local_confseed';
 $plugin->maturity = MATURITY_BETA;

--- a/version.php
+++ b/version.php
@@ -33,16 +33,6 @@ if (file_exists($CFG->dirroot . '/config-seed.php')) {
         $plugin->version = $CONFSEED->version;
     }
 }
-
-// Legacy CONFSEED setup.
-if (!isset($plugin->version)) {
-    if (isset($CFG->CONFSEED) && isset($CFG->CONFSEED->version)) {
-        $plugin->version = $CFG->CONFSEED->version;
-    } else {
-        $plugin->version = '2018043000';
-    }
-}
-
 // The rolesactive = 1 marks a finished Moodle install.
 if ($CFG->rolesactive != 1) {
     // Pretend it's a one-off lower version, so we can install+upgrade in one step.


### PR DESCRIPTION
This "fixes" the "initial install" problem, at the expense of having to "install+upgrade" when installing (Or get a prompt as admin).

This is because some settings (such as the themes') are reset by Moodle's install/upgrade process, see https://github.com/moodle/moodle/blob/master/lib/installlib.php#L509

Relying on `rolesactive` from https://github.com/moodle/moodle/blob/master/lib/installlib.php#L502 seems to be enough to detect if the install has run or not. It's never altered after installation.

(Also, deprecating an old "$CFG->CONFSEED" syntax that we don't want to support anymore)